### PR TITLE
add option dontBlurOnMouseDown for textfield

### DIFF
--- a/textfield/textfield.es6.js
+++ b/textfield/textfield.es6.js
@@ -327,6 +327,9 @@ const component = {
             }
             // write
             hasFocus = state;
+            if (opts.dontBlurOnMouseDown) {
+                return;
+            }
             if (hasFocus) {
                 document.body.addEventListener(startEventType, onMouseDown);
             } else {


### PR DESCRIPTION
hi, thank you for creating polythene, it saves a lot of my time to creating "production level" UI :D

### motivation
currently, textfield component hides software keyboard when it loses focus. so if more than one text input in page (that is common for login form), user will see 
1. tap first text input. software keyboard popup
2. finish to input for first, then tap second text input
3. software keyboard hides, then shows immediately. 

for me, these behavior cause laggy impression for the UI. actually, some of famous mobile app like google inbox (at composing mail), facebook mobile app (at event creation), slack (at create channel) doesn't hide software keyboard until focus is set to some of its text input. 

so I think its worth making it possible as option (I don't think this name is not best for its purpose. but I did not come up with good name for it)

### implementation
- add new option dontBlurOnMouseDown to textfield component
- if dontBlurOnMouseDown is set, textfield does not set OnMouseDown event handler to startEventType.
