### PR TITLE
initial checkedValue is null

### DIFF
--- a/packages/polythene-core-radio-group/src/radio-group.js
+++ b/packages/polythene-core-radio-group/src/radio-group.js
@@ -45,7 +45,7 @@ export const createContent = (vnode, { renderer: h, RadioButton }) => {
         return null;
       }
       // Only set defaultChecked the first time when no value has been stored yet
-      const isDefaultChecked = (buttonOpts.defaultChecked || buttonOpts.checked) && checkedValue === undefined;
+      const isDefaultChecked = (buttonOpts.defaultChecked || buttonOpts.checked) && checkedValue === null;
       if (buttonOpts.value === undefined) {
         console.error("Option 'value' not set for radio button"); // eslint-disable-line no-console
       }


### PR DESCRIPTION
Currently mithril radio groups do not work with defaultChecked.

This PR is to update the initial state comparison in createContent to align with the actual initial checkedValue which is null.

Initiate state value:  https://github.com/ArthurClemens/polythene/blob/master/packages/polythene-core-radio-group/src/radio-group.js#L8