### PR TITLE
 List Tile: fix typos in selectors for secondary

### DIFF
--- a/packages/polythene-css-list-tile/src/color.js
+++ b/packages/polythene-css-list-tile/src/color.js
@@ -13,7 +13,7 @@ const selected = (selector, vars, tint) => {
       }
       : undefined
     ),
-    " .pe-list-tile__primary, pe-list-tile__secondary": {
+    " .pe-list-tile__primary, .pe-list-tile__secondary": {
       backgroundColor: vars["color_" + tint + "_selected_background"]
     }
   });
@@ -23,7 +23,7 @@ const generalFns = ({
   general_styles: selector => [
     sel(selector, {
       ".pe-list-tile--header": {
-        " .pe-list-tile__primary, pe-list-tile__secondary": {
+        " .pe-list-tile__primary, .pe-list-tile__secondary": {
           backgroundColor: "inherit"
         }
       },
@@ -95,7 +95,7 @@ const tintFns = tint => ({
   ["color_" + tint + "_highlight_background"]: (selector, vars) => [
     sel(selector, {
       ".pe-list-tile--highlight:not(.pe-list-tile--selected)": {
-        " .pe-list-tile__primary, pe-list-tile__secondary": {
+        " .pe-list-tile__primary, .pe-list-tile__secondary": {
           backgroundColor: vars["color_" + tint + "_highlight_background"]
         }
       },


### PR DESCRIPTION
Hi @ArthurClemens, just found a few typos in the selectors for ListTile. This caused colors not to be reflected properly to the secondary content in a list tile.